### PR TITLE
Fix loading of IC3+ data

### DIFF
--- a/lib/pymice/_ICData.py
+++ b/lib/pymice/_ICData.py
@@ -1307,6 +1307,6 @@ class ZipLoader_v_version1(_ZipLoaderBase):
 ZIP_LOADERS = {
   'version1': ZipLoader_v_version1,
   'version_2_2': ZipLoader_v_version_2_2,
-  'IntelliCage_Plus_3': ZipLoader_v_IntelliCage_Plus_3,
-  'IntelliCage_Plus_3_1': ZipLoader_v_IntelliCage_Plus_3_1,
+  'intellicage_plus_3': ZipLoader_v_IntelliCage_Plus_3,
+  'intellicage_plus_3_1': ZipLoader_v_IntelliCage_Plus_3_1,
 }


### PR DESCRIPTION
Keys of `ZIP_LOADERS` are required to be lowercase.